### PR TITLE
Ability to map between NSString and NSNumber

### DIFF
--- a/FastEasyMapping/Source/Extensions/Foundation/NSObject+FEMKVC.m
+++ b/FastEasyMapping/Source/Extensions/Foundation/NSObject+FEMKVC.m
@@ -19,11 +19,42 @@
 // THE SOFTWARE.
 
 #import "NSObject+FEMKVC.h"
+#import <objc/runtime.h>
 
 @implementation NSObject (FEMKVC)
 
+- (char *)emk_classNameForProperty:(NSString *)key {
+    char *className = "";
+    objc_property_t property = class_getProperty(object_getClass(self), [key UTF8String]);
+    char *type = property_copyAttributeValue(property, "T");
+    if (strlen(type)>3) {
+        className = strndup(type+2, strlen(type)-3);
+    }
+    free(type);
+    return className;
+}
+
+static char * const classTypeString = "NSString";
+static char * const classTypeNumber = "NSNumber";
+
+- (BOOL)emk_propertyIsString:(NSString *)key {
+    return (strcmp([self emk_classNameForProperty:key],classTypeString) == 0);
+}
+
+- (BOOL)emk_propertyIsNumber:(NSString *)key {
+    return (strcmp([self emk_classNameForProperty:key],classTypeNumber) == 0);
+}
+
 - (void)emk_setValueIfDifferent:(id)value forKey:(NSString *)key {
+    
 	id _value = [self valueForKey:key];
+    
+    if ([value isKindOfClass:NSNumber.class] && [self emk_propertyIsString:key]) {
+        value = [(NSNumber *)value stringValue];
+    } else if ([value isKindOfClass:NSString.class] && [self emk_propertyIsNumber:key]) {
+        //value = [[NSNumberFormatter new] numberFromString:value];
+        value = @([(NSString *)value floatValue]);
+    }
 
 	if (_value != value && ![_value isEqual:value]) {
 		[self setValue:value forKey:key];


### PR DESCRIPTION
A patch to give ability to populate the `NSString` property with `NSNumber` in JSON, and `NSNumber` with `NSString`. 

Tested with Xcode 6: Performance dropped down for this method by 15-20%.

I tried optimising it, but if you have any recommendations....
