### PR TITLE
[add] class method to create attribute mapping for NSNumber values

### DIFF
--- a/FastEasyMapping/Source/Core/Mapping/Attribute/FEMAttribute.h
+++ b/FastEasyMapping/Source/Core/Mapping/Attribute/FEMAttribute.h
@@ -48,4 +48,9 @@
 */
 + (instancetype)mappingOfURLProperty:(NSString *)property toKeyPath:(NSString *)keyPath;
 
+/**
+ * property represented by NSNumber, value at keyPath - NSString
+ */
++ (instancetype)mappingOfNumberProperty:(NSString *)property toKeyPath:(NSString *)keyPath;
+
 @end

--- a/FastEasyMapping/Source/Core/Mapping/Attribute/FEMAttribute.m
+++ b/FastEasyMapping/Source/Core/Mapping/Attribute/FEMAttribute.m
@@ -98,4 +98,12 @@
     }];
 }
 
++ (instancetype)mappingOfNumberProperty:(NSString *)property toKeyPath:(NSString *)keyPath {
+    return [FEMAttribute mappingOfProperty:property toKeyPath:keyPath map:^id(id value) {
+        return [value isKindOfClass:NSString.class] ? @([value doubleValue]) : NSNull.null;
+    }                           reverseMap:^id(NSNumber *value) {
+        return [value stringValue];
+    }];
+}
+
 @end


### PR DESCRIPTION
I just don't wanna every time write this:
```
[mapping addAttribute:[FEMAttribute mappingOfProperty:@"rating" toKeyPath:@"rating" map:^id(id value) {
    return @([value doubleValue]);
}]];
```

I wanna use this:
```
[mapping addAttribute:[FEMAttribute mappingOfNumberProperty:@"rating" toKeyPath:@"rating"]];
```