### PR TITLE
Fix crash when relationship is (null)

### DIFF
--- a/FastEasyMapping/Source/Core/Cache/FEMManagedObjectCache.m
+++ b/FastEasyMapping/Source/Core/Cache/FEMManagedObjectCache.m
@@ -83,10 +83,10 @@
 	NSParameterAssert(object);
 
 	id primaryKeyValue = [object valueForKey:mapping.primaryKey];
-    if (primaryKeyValue) {
-        NSMutableDictionary *entityObjectsMap = [self cachedObjectsForMapping:mapping];
-        entityObjectsMap[primaryKeyValue] = object;
-    }
+	if (primaryKeyValue) {
+		NSMutableDictionary *entityObjectsMap = [self cachedObjectsForMapping:mapping];
+		entityObjectsMap[primaryKeyValue] = object;
+	}
 }
 
 - (NSDictionary *)existingObjectsForMapping:(FEMMapping *)mapping {

--- a/FastEasyMapping/Source/Core/Cache/FEMManagedObjectCache.m
+++ b/FastEasyMapping/Source/Core/Cache/FEMManagedObjectCache.m
@@ -83,10 +83,10 @@
 	NSParameterAssert(object);
 
 	id primaryKeyValue = [object valueForKey:mapping.primaryKey];
-	NSAssert(primaryKeyValue, @"No value for key (%@) on object (%@) found", mapping.primaryKey, object);
-
-	NSMutableDictionary *entityObjectsMap = [self cachedObjectsForMapping:mapping];
-    entityObjectsMap[primaryKeyValue] = object;
+    if (primaryKeyValue) {
+        NSMutableDictionary *entityObjectsMap = [self cachedObjectsForMapping:mapping];
+        entityObjectsMap[primaryKeyValue] = object;
+    }
 }
 
 - (NSDictionary *)existingObjectsForMapping:(FEMMapping *)mapping {


### PR DESCRIPTION
For example when `movies` is:

```
[
{
   "id": 666,
   "title": "Foo",
   "year": 2014,
   "categoty_id": 54,
},
{
   "id": 777,
   "title": "Bar",
   "year": 2015,
   "categoty_id": null,
},
…
]
```

And mapping is:

```
+ (FEMMapping *)mapping
{
    FEMMapping *mapping = [[FEMMapping alloc] initWithEntityName:@"Movie"];
    [mapping addAttributesFromArray:@[@"title",@"year"]];
    mapping.primaryKey = @"movie_id";
    [mapping addAttributesFromDictionary:@{@"movie_id": @"id"}];

    FEMMapping *fakeCategoryMapping = [[FEMMapping alloc] initWithEntityName:@"Category"];
    fakeCategoryMapping.primaryKey = @"category_id";
    [fakeCategoryMapping addAttributesFromDictionary:@{@"category_id": @"category_id"}];
    [mapping addRelationshipMapping: fakeCategoryMapping forProperty:@"category" keyPath:nil];

    return mapping;
}
```

App crashes on `assert`, but should not. So fix is for this.
