### PR TITLE
Fix broken relationships when using FEM and CoreData

### DIFF
--- a/FastEasyMapping/Source/Core/Deserializer/FEMDeserializer.m
+++ b/FastEasyMapping/Source/Core/Deserializer/FEMDeserializer.m
@@ -68,7 +68,11 @@
                                                      allocateIfNeeded:!relationship.weak];
 
                     objc_property_t property = class_getProperty([object class], [relationship.property UTF8String]);
-                    targetValue = [targetValue fem_propertyRepresentation:property];
+                    if (property == NULL && [object isKindOfClass:[NSManagedObject class]]) {
+                        targetValue = [NSSet setWithArray:targetValue];
+                    } else {
+                        targetValue = [targetValue fem_propertyRepresentation:property];
+                    }
                 } else {
                     targetValue = [self _objectFromRepresentation:relationshipRepresentation
                                                           mapping:relationship.mapping


### PR DESCRIPTION
We ran into this crash: "Unacceptable type of value for to-many relationship: property = "foo"; desired type = NSSet; given type = __NSArrayM; value = (...)"
Turns out, that class_getProperty does not work for NSManagedObject and returns NULL.
In this case fem_propertyRepresentation defaults to [NSArray class] which causes the
above error.

credits to @dlalic for pointing this out and providing a fix.