### PR TITLE
Update build status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastEasyMapping
 
-[![Build Status](https://travis-ci.org/Yalantis/FastEasyMapping.svg)](https://travis-ci.org/Yalantis/FastEasyMapping)
+[![Build Status](https://travis-ci.org/Yalantis/FastEasyMapping.svg?branch=master)](https://travis-ci.org/Yalantis/FastEasyMapping)
 [![codecov.io](https://codecov.io/github/Yalantis/FastEasyMapping/coverage.svg?branch=master)](https://codecov.io/github/Yalantis/FastEasyMapping?branch=master)
 
 ### Note


### PR DESCRIPTION
Build status is for some reason red, but it is actually green when you open travis link. I just filtered master branch, which is probably what we want anyway.