### PR TITLE
Fix fragile test

### DIFF
--- a/FastEasyMappingTests/Specs/FEMSerializerSpec.m
+++ b/FastEasyMappingTests/Specs/FEMSerializerSpec.m
@@ -128,11 +128,14 @@ SPEC_BEGIN(FEMSerializerSpec)
 
 				__block CarNative *car;
 				__block NSDictionary *representation;
-				__block NSDate *date = [NSDate date];
+				__block NSDate *referenceDate = [NSDate dateWithTimeIntervalSince1970:0];
 
-				NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-				[formatter setDateFormat:@"yyyy-MM-dd"];
-				__block NSString *dateString = [formatter stringFromDate:date];
+                NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
+                dayComponent.day = 1;
+                NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+
+                __block NSDate *date = [calendar dateByAddingComponents:dayComponent toDate:referenceDate options:0];
+                __block NSString *dateString = @"1970-01-02";
 
 				beforeEach(^{
 


### PR DESCRIPTION
This test failed on my machine because of I think localization settings.
But regardless of that, every time it is run it uses different date instance and test and implementation use very similar code (string is calculated in test)